### PR TITLE
Allow language to be the only path part in URI

### DIFF
--- a/src/Mvc/Router/Http/LanguageTreeRouteStack.php
+++ b/src/Mvc/Router/Http/LanguageTreeRouteStack.php
@@ -144,7 +144,16 @@ class LanguageTreeRouteStack extends TranslatorAwareTreeRouteStack
         if (count($languages) > 1 && in_array($pathParts[0], $languageKeys)) {
             // if language was provided, save the locale and adjust the baseUrl
             $locale = $languages[$pathParts[0]];
-            $this->setBaseUrl($oldBase . '/' . $pathParts[0]);
+
+            // if only the language was provided
+            if (count($pathParts) === 1) {
+                $this->baseUrl = '';
+                $uri->setPath('/');
+                $pathOffset = 0;
+            // if the language was provided along with other path parts
+            } else {
+                $this->setBaseUrl($oldBase . '/' . $pathParts[0]);
+            }
         } elseif (! empty($this->getAuthenticationService()) && $this->getAuthenticationService()->hasIdentity()) {
             // try to get user language if no language was provided by url
             $user = $this->getAuthenticationService()->getIdentity();

--- a/tests/src/Mvc/Router/Http/LanguageTreeRouteStackMatchTest.php
+++ b/tests/src/Mvc/Router/Http/LanguageTreeRouteStackMatchTest.php
@@ -90,6 +90,34 @@ class LanguageTreeRouteStackMatchTest extends TestCase
      * @covers ::match
      * @covers ::getLastMatchedLocale
      */
+    public function matchLocaleFromURIWithoutPath(): void
+    {
+        $translator = $this->prophesize(Translator::class);
+        $translator->getLocale()->willReturn('de_DE');
+
+        $options = new LanguageRouteOptions();
+        $this->route->setLanguageOptions($options);
+
+        $this->route->setBaseUrl('/');
+        $this->route->addRoute('phpunit', ['type' => 'literal', 'options' => ['route' => '/']]);
+
+        $uri     = new URI('http://phpunit/de');
+        $request = $this->prophesize(Request::class);
+        $request->getUri()->willReturn($uri);
+
+        $routeMatch = $this->route->match($request->reveal(), null, ['translator' => $translator->reveal()]);
+        $this->assertInstanceOf(RouteMatch::class, $routeMatch);
+        $this->assertSame('phpunit', $routeMatch->getMatchedRouteName());
+        $this->assertSame(['locale' => 'de_DE'], $routeMatch->getParams());
+        $this->assertSame('', $this->route->getBaseUrl());
+        $this->assertSame('de_DE', $this->route->getLastMatchedLocale());
+    }
+
+    /**
+     * @test
+     * @covers ::match
+     * @covers ::getLastMatchedLocale
+     */
     public function matchLocaleFromURIWithBaseURLFormRequest(): void
     {
         $translator = $this->prophesize(Translator::class);


### PR DESCRIPTION
This pull request allows URLs like `http://www.example.com/de` to be valid, as they previously resulted in a `404` when the language was the only part in the path segment.